### PR TITLE
Add logging of print statements

### DIFF
--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: 3.10
+          python-version: "3.10"
           environment-file: environment.yaml
       - name: Run pytest
         shell: bash -l {0}

--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build Conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment.yaml
       - name: Run pytest

--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -31,7 +31,7 @@ jobs:
           activate-environment: pvade
       - name: Run pytest
         shell: bash -l {0}
-        run: pytest -sv pvade/tests/
+        run: PYTHONPATH=. pytest -sv pvade/tests/
 
   # Job 2 of 2 - enforce Black formatting
   formatting:

--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -23,8 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build Conda environment
-        uses: mamba-org/setup-micromamba@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           environment-file: environment.yaml
       - name: Run pytest
         shell: bash -l {0}

--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
+          python-version: 3.10
           environment-file: environment.yaml
       - name: Run pytest
         shell: bash -l {0}

--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -28,6 +28,7 @@ jobs:
           auto-update-conda: true
           python-version: "3.10"
           environment-file: environment.yaml
+          activate-environment: pvade
       - name: Run pytest
         shell: bash -l {0}
         run: pytest -sv pvade/tests/

--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -21,12 +21,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build Conda environment
         uses: conda-incubator/setup-miniconda@v3
         with:
           # auto-update-conda: true
-          python-version: "3.11"
+          python-version: "3.10"
           environment-file: environment.yaml
           activate-environment: pvade
       - name: Run pytest
@@ -38,5 +38,5 @@ jobs:
     name: Black formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: psf/black@stable

--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -25,8 +25,8 @@ jobs:
       - name: Build Conda environment
         uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-update-conda: true
-          python-version: "3.10"
+          # auto-update-conda: true
+          python-version: "3.11"
           environment-file: environment.yaml
           activate-environment: pvade
       - name: Run pytest

--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build Conda environment
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -35,5 +35,5 @@ jobs:
     name: Black formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: psf/black@stable

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,7 +1,6 @@
 name: pvade
 channels:
   - conda-forge  
-  - defaults
 dependencies:
   # Dependencies should be kept as loosely pinned to version numbers as possible
   - alive-progress

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,6 +1,7 @@
 name: pvade
 channels:
   - conda-forge  
+  - nodefaults
 dependencies:
   # Dependencies should be kept as loosely pinned to version numbers as possible
   - alive-progress

--- a/pvade/IO/DataStream.py
+++ b/pvade/IO/DataStream.py
@@ -55,7 +55,8 @@ def start_print_and_log(rank, logfile_name):
     sys.stdout = PrintAndLog(logfile_name, rank, message_type="INFO")
     sys.stderr = PrintAndLog(logfile_name, rank, message_type="ERROR")
 
-    print("Starting PVade Run")
+    if rank == 0:
+        print("Starting PVade Run")
 
 
 class DataStream:

--- a/pvade/IO/DataStream.py
+++ b/pvade/IO/DataStream.py
@@ -1,22 +1,63 @@
-# from dolfinx import *
-import numpy as np
-import time
-import os
-import shutil
-from dolfinx.io import XDMFFile, VTKFile
-from mpi4py import MPI
-from pathlib import Path
-import pytest
-import dolfinx
-from petsc4py import PETSc
-import json
+from dolfinx.io import XDMFFile
 
-# from dolfinx.fem import create_nonmatching_meshes_interpolation_data
-
-# hello
+# import logging
+import sys
+from datetime import datetime
 
 
-# test actions
+def start_print_and_log(rank, logfile_name):
+
+    class PrintAndLog:
+        """
+        A class to capture normal print statements in a log file
+        along with displaying them to the terminal as usual.
+        """
+
+        def __init__(self, logfile_name, rank, message_type):
+            self.logfile_name = logfile_name
+            self.rank = rank
+            self.message_type = message_type
+
+            if message_type == "INFO":
+                self.terminal = sys.__stdout__
+            elif message_type == "ERROR":
+                self.terminal = sys.__stdout__
+            else:
+                raise ValueError(f"Type {message_type} not recognized")
+
+        def write(self, message):
+            # Write to both the command line and save to the logfile
+            cleaned_message = message.rstrip()
+
+            # Can include a test like `len(message) > 0 and self.rank == 0`
+            # to limit this to only printing from rank 0, but for parallel
+            # debugging, it is often helpful to see messages from all ranks
+            # so we omit this check for now.
+            if len(cleaned_message) > 0:
+
+                cleaned_message += "\n"
+
+                self.terminal.write(f"{cleaned_message}")
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+                with open(self.logfile_name, "a") as fp:
+                    fp.write(f"{timestamp} [{self.message_type}] {cleaned_message}")
+
+        def flush(self):
+            # Dummy method
+            pass
+
+    with open(logfile_name, "w") as fp:
+        # Start with an empty file
+        pass
+
+    # Redirect stdout and stderr
+    sys.stdout = PrintAndLog(logfile_name, rank, message_type="INFO")
+    sys.stderr = PrintAndLog(logfile_name, rank, message_type="ERROR")
+
+    print("Starting PVade Run")
+
+
 class DataStream:
     """Input/Output and file writing class
 
@@ -49,11 +90,6 @@ class DataStream:
         self.num_procs = params.num_procs
         self.ndim = domain.fluid.msh.topology.dim
         self.thermal_analysis = params.general.thermal_analysis
-
-        self.log_filename = f"{params.general.output_dir_sol}/log.txt"
-        if self.rank == 0:
-            with open(self.log_filename, "w") as fp:
-                fp.write("Run Started.\n")
 
         # If doing a fluid simulation, start a fluid solution file
         if params.general.fluid_analysis:
@@ -170,13 +206,6 @@ class DataStream:
             raise ValueError(
                 f"Got found fsi object name = {fsi_object.name}, not recognized."
             )
-
-    def print_and_log(self, string_to_print):
-        if self.rank == 0:
-            print(string_to_print)
-
-            with open(self.log_filename, "a") as fp:
-                fp.write(f"{string_to_print}\n")
 
     # def fluid_struct(self, domain, flow, elasticity, params):
     #     # print("tst")

--- a/pvade/IO/Utilities.py
+++ b/pvade/IO/Utilities.py
@@ -8,7 +8,7 @@ def get_input_file():
         "--input_file",
         metavar="",
         type=str,
-        help="The full path to the input file, e.g., 'intputs/my_params.yaml'",
+        help="The full path to the input file, e.g., 'inputs/my_params.yaml'",
     )
 
     command_line_inputs, unknown = parser.parse_known_args()

--- a/pvade_main.py
+++ b/pvade_main.py
@@ -1,5 +1,5 @@
 from pvade.fluid.FlowManager import Flow
-from pvade.IO.DataStream import DataStream
+from pvade.IO.DataStream import DataStream, start_print_and_log
 from pvade.fsi.FSI import FSI
 from pvade.IO.Parameters import SimParams
 from pvade.IO.Utilities import get_input_file, write_metrics
@@ -24,6 +24,9 @@ def main(input_file=None):
 
     # Load the parameters object specified by the input file
     params = SimParams(input_file)
+
+    logfile_name = os.path.join(params.general.output_dir, "logfile.log")
+    start_print_and_log(params.rank, logfile_name)
 
     fluid_analysis = params.general.fluid_analysis
     structural_analysis = params.general.structural_analysis


### PR DESCRIPTION
This PR adds a function to redirect all normal print statements to also be captured in a logfile. The file is situated at the top-level output directory, e.g., `{params.general.output_dir}/logfile.log`. Entries in the logfile are timestamped and marked `INFO` or `ERROR`.

Changes:

- Call the `start_print_and_log` function immediately after parsing the user params
- Added a function to redirect stdout and stderr to the normal terminal/command line display but also write a copy of the message to a log file

closes #56 