### PR TITLE
Adding atmospheric stability correction to log law inflow profile

### DIFF
--- a/pvade/IO/input_schema.yaml
+++ b/pvade/IO/input_schema.yaml
@@ -353,6 +353,13 @@ properties:
         type: "number"
         description: "The zero plane displacement height used for the presence of vegetated or urban canopies in the log law velocity profile."
         units: "meters"
+      psi:
+        default: 0.0
+        minimum: -10.0
+        maximum: 5.0
+        type: "number"
+        description: "Atmospheric stability correction function: negative for unstable (convective, daytime) conditions, positive for stable (night-time) conditions, zero for neutral conditions."
+        units: "none"
       initialize_with_inflow_bc:
         default: true
         type: "boolean"

--- a/pvade/IO/input_schema.yaml
+++ b/pvade/IO/input_schema.yaml
@@ -358,7 +358,7 @@ properties:
         minimum: -10.0
         maximum: 5.0
         type: "number"
-        description: "Atmospheric stability correction function: negative for unstable (convective, daytime) conditions, positive for stable (night-time) conditions, zero for neutral conditions."
+        description: "Atmospheric stability correction function for log law: negative for unstable (convective, daytime) conditions, positive for stable (night-time) conditions, zero for neutral conditions."
         units: "none"
       initialize_with_inflow_bc:
         default: true

--- a/pvade/fluid/boundary_conditions.py
+++ b/pvade/fluid/boundary_conditions.py
@@ -176,23 +176,24 @@ class InflowVelocity:
         elif self.params.fluid.velocity_profile_type == "loglaw":
             z0 = self.params.fluid.z0
             d0 = self.params.fluid.d0
+            psi = self.params.fluid.psi
             z_hub = self.params.pv_array.elevation
 
             # handle panels3d
             if self.ndim == 3:
                 inflow_values[0] = (
                     (time_vary_u_ref)
-                    * np.log(((x[2]) - d0) / z0)
-                    / (np.log((z_hub - d0) / z0))
+                    * (np.log(((x[2]) - d0) / z0) - psi)
+                    / (np.log((z_hub - d0) / z0) - psi)
                 )
 
             # handle panels2d
             elif self.ndim == 2:
                 # print("this is 2d")
                 inflow_values[0] = (
-                    (time_vary_u_ref)  # shouldn't this be u_star?
-                    * np.log(((x[1]) - d0) / z0)
-                    / (np.log((z_hub - d0) / z0))
+                    (time_vary_u_ref)
+                    * (np.log(((x[1]) - d0) / z0) - psi)
+                    / (np.log((z_hub - d0) / z0) - psi)
                 )
 
         # if self.first_call_to_inflow_velocity:


### PR DESCRIPTION
This PR adds `psi` to the log law inflow velocity profile equation to allow for additional modification of the inflow profile by the user. This feature is useful when trying to match two wind speeds at two heights.

Background:


