### PR TITLE
adjust limits of psi and z0 to prevent negative u values

### DIFF
--- a/pvade/IO/input_schema.yaml
+++ b/pvade/IO/input_schema.yaml
@@ -342,7 +342,7 @@ properties:
       z0:
         default: 0.05
         minimum: 0.001
-        maximum: 10.0
+        maximum: 0.1
         type: "number"
         description: "The surface roughness length used in the log law velocity profile."
         units: "meters"
@@ -356,7 +356,7 @@ properties:
       psi:
         default: 0.0
         minimum: -10.0
-        maximum: 5.0
+        maximum: 0.7
         type: "number"
         description: "Atmospheric stability correction function for log law: negative for unstable (convective, daytime) conditions, positive for stable (night-time) conditions, zero for neutral conditions."
         units: "none"


### PR DESCRIPTION
Previous PR #94 added the atmospheric stability correction term (`psi`) to the log law inflow profile. This new term can create negative inflow velocity values at large, positive values of `psi`. 

To address this issue, this PR sets the limit of `psi` to 0.7 in the `input_schema.yaml` file. This value of 0.7 represents slightly stable atmospheric conditions (when the ground is slightly colder than the air).

This PR also changes the upper limit of z0 to be 0.1, which is the equivalent of many trees. Above this value is representative of buildings, which PVade is not yet designed to simulate. Additionally, values of z0 > 0.1 may also lead to negative inflow velocity values at the upper limits of psi.