### PR TITLE
To address missing pkg_resources error

### DIFF
--- a/.github/workflows/test_pvade.yaml
+++ b/.github/workflows/test_pvade.yaml
@@ -43,3 +43,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
+        with:
+          version: "25.1"

--- a/environment.yaml
+++ b/environment.yaml
@@ -19,6 +19,7 @@ dependencies:
   - python-gmsh
   - pyyaml
   - scipy
+  - setuptools=80.9.0
   - snakeviz
   - sphinx
   - tqdm


### PR DESCRIPTION
When I build the conda/mamba environment from `environment.yaml`, the most updated version of `setuptools` that gets installed does not have `pkg_resources` because it has been deprecated. As a bandaid fix, this PR pins the `setuptools` version to avoid missing pkg_resources error.

With this fix, we still see this warning when running pvade:
`/kfs2/projects/pvade/bstanisl/envs/pvade/lib/python3.10/site-packages/ufl/__init__.py:244: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources`